### PR TITLE
Created Github Actions config

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,5 +15,3 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: make
-    - name: make distcheck
-      run: make distcheck

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,7 +15,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: make
-    - name: make check
-      run: make check
     - name: make distcheck
       run: make distcheck

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,21 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,4 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: make
-      run: make
+      run: |
+        make
+        ls

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,12 +8,23 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
+    
     - uses: actions/checkout@v2
+    
     - name: make
+      run: make
+      
+    - name: move binaries
       run: |
-        make
-        ls
+        mkdir upload
+        mv ./CASBACnetStackCompileTest ./upload/
+    
+    - name: upload artifact
+    - uses: actions/upload-artifact@v2
+      with:
+        name: binary
+        path: upload
+    
+        

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,7 +22,7 @@ jobs:
         mv ./CASBACnetStackCompileTest ./upload/
     
     - name: upload artifact
-    - uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2
       with:
         name: binary
         path: upload


### PR DESCRIPTION
This Github Action config auto-builds the test on every push to main, and uploads the binary for download.
Best to merge with squashed commits.